### PR TITLE
feat: Allow connection or pool promise

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "neat-mysql",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "neat-mysql",
-  "version": "1.0.21",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neat-mysql",
-  "version": "1.0.24",
+  "version": "2.0.0",
   "description": "a neat way to interact with MySQL from Node.js",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neat-mysql",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "a neat way to interact with MySQL from Node.js",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Allows user to pass either `Connection | Pool` or `Promise<Connection | Pool>` to convenience functions (`query`, `execute`, etc)